### PR TITLE
Removed notation for npm bootstrap. It's already included in  Angular…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -427,8 +427,6 @@ module.exports = function (grunt) {
 
   });
 
-  grunt.loadNpmTasks('grunt-bootstrap');
-
 
   grunt.registerTask('serve', 'Compile then start a connect web server', function (target) {
     if (target === 'dist') {


### PR DESCRIPTION
… according to the docs.